### PR TITLE
chore: lint code and improve linter settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,33 @@
 linters-settings:
   cyclop:
     max-complexity: 27
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        allow:
+          - $gostd
+          - k8s.io/api
+          - k8s.io/apimachinery
+          - k8s.io/client-go
+          - github.com/projectcapsule
+          - github.com/go-logr/logr
+          - github.com/pkg/errors
+          - github.com/spf13/cobra
+          - sigs.k8s.io/controller-runtime
+  funlen:
+    lines: 110
   gci:
     sections:
       - standard # Captures all standard packages if they do not match another section.
       - default # Contains all imports that could not be matched to another section type.
-      - prefix(github.com/projectcapsule/capsule-addon-fluxcd) # Groups all imports with the specified Prefix.
+      - prefix(github.com/projectcapsule/capsule-addon-flux) # Groups all imports with the specified Prefix.
   goconst:
     min-len: 2
     min-occurrences: 3
   goheader:
     template: |-
-      Copyright 2020-2023 Project Capsule Authors.
+      Copyright 2020-2024 Project Capsule Authors.
       SPDX-License-Identifier: Apache-2.0
   govet:
     check-shadowing: true

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,3 +1,6 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 const (

--- a/cmd/manager/constants.go
+++ b/cmd/manager/constants.go
@@ -1,3 +1,6 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package manager
 
 const (

--- a/cmd/manager/manager.go
+++ b/cmd/manager/manager.go
@@ -1,8 +1,13 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package manager
 
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
@@ -11,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -56,6 +60,7 @@ func New() *cobra.Command {
 
 	// Add Zap options.
 	var fs flag.FlagSet
+
 	opts.Zo.BindFlags(&fs)
 	cmd.Flags().AddGoFlagSet(&fs)
 
@@ -67,6 +72,7 @@ func (o *Options) Run(_ *cobra.Command, _ []string) error {
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		return errors.Wrap(err, "unable to add client-go types to the manager's scheme")
 	}
+
 	if err := capsulev1beta2.AddToScheme(scheme); err != nil {
 		return errors.Wrap(err, "unable to add Capsule types to the manager's scheme")
 	}
@@ -87,6 +93,7 @@ func (o *Options) Run(_ *cobra.Command, _ []string) error {
 	})
 	if err != nil {
 		o.SetupLog.Error(err, "unable to create manager")
+
 		return errors.Wrap(err, "unable to create manager")
 	}
 
@@ -102,6 +109,7 @@ func (o *Options) Run(_ *cobra.Command, _ []string) error {
 
 	if err = indexer.AddToManager(ctx, o.SetupLog, mgr); err != nil {
 		o.SetupLog.Error(err, "unable to setup indexers")
+
 		return errors.Wrap(err, "unable to setup indexers")
 	}
 
@@ -112,11 +120,13 @@ func (o *Options) Run(_ *cobra.Command, _ []string) error {
 		serviceaccount.WithProxyURL(o.ProxyURL),
 	).SetupWithManager(ctx, mgr); err != nil {
 		o.SetupLog.Error(err, "unable to create manager", "controller", "ServiceAccount")
+
 		return errors.Wrap(err, "unable to setup the service account controller")
 	}
 
 	if err = mgr.Start(ctx); err != nil {
 		o.SetupLog.Error(err, "problem running manager")
+
 		return errors.Wrap(err, "unable to start the manager")
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,12 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (
-	"github.com/projectcapsule/capsule-addon-flux/cmd/manager"
 	"github.com/spf13/cobra"
+
+	"github.com/projectcapsule/capsule-addon-flux/cmd/manager"
 )
 
 func New() *cobra.Command {
@@ -17,5 +21,6 @@ func New() *cobra.Command {
 
 func Execute() error {
 	cmd := New()
+
 	return cmd.Execute()
 }

--- a/e2e/charts/serviceaccount_test.go
+++ b/e2e/charts/serviceaccount_test.go
@@ -1,5 +1,8 @@
 //go:build e2e
 
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package charts
 
 import (

--- a/e2e/charts/suite_test.go
+++ b/e2e/charts/suite_test.go
@@ -1,5 +1,8 @@
 //go:build e2e
 
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package charts
 
 import (

--- a/e2e/serviceaccount_test.go
+++ b/e2e/serviceaccount_test.go
@@ -1,5 +1,8 @@
 //go:build e2e
 
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -1,5 +1,8 @@
 //go:build e2e
 
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package e2e
 
 import (

--- a/e2e/utils/utils.go
+++ b/e2e/utils/utils.go
@@ -1,5 +1,8 @@
 //go:build e2e
 
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package utils
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (
@@ -9,6 +12,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
+		//nolint:forbidigo
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/controller/serviceaccount/constants.go
+++ b/pkg/controller/serviceaccount/constants.go
@@ -1,3 +1,6 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package serviceaccount
 
 const (

--- a/pkg/controller/serviceaccount/errors.go
+++ b/pkg/controller/serviceaccount/errors.go
@@ -1,3 +1,6 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package serviceaccount
 
 import "github.com/pkg/errors"

--- a/pkg/controller/serviceaccount/globaltenantresources.go
+++ b/pkg/controller/serviceaccount/globaltenantresources.go
@@ -1,7 +1,11 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package serviceaccount
 
 import (
 	"context"
+
 	capsulev1beta2 "github.com/projectcapsule/capsule/api/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/controller/serviceaccount/rolebindings.go
+++ b/pkg/controller/serviceaccount/rolebindings.go
@@ -1,8 +1,12 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package serviceaccount
 
 import (
 	"context"
 	"fmt"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/pkg/controller/serviceaccount/tokens.go
+++ b/pkg/controller/serviceaccount/tokens.go
@@ -1,10 +1,13 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package serviceaccount
 
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -34,6 +37,7 @@ func (r *ServiceAccountReconciler) ensureSATokenSecret(ctx context.Context, name
 
 			return nil
 		}
+
 		return err
 	}
 
@@ -44,7 +48,6 @@ func (r *ServiceAccountReconciler) ensureSATokenSecret(ctx context.Context, name
 // are specified as arguments.
 func (r *ServiceAccountReconciler) getSATokenSecret(ctx context.Context, saName, saNamespace string) (*corev1.Secret, error) {
 	saTokenList := new(corev1.SecretList)
-	// TODO: filter by Service Account-type and Namespace. Need index by Secret type.
 	if err := r.Client.List(ctx, saTokenList); err != nil {
 		return nil, ErrServiceAccountTokenNotFound
 	}
@@ -54,15 +57,16 @@ func (r *ServiceAccountReconciler) getSATokenSecret(ctx context.Context, saName,
 	}
 
 	var tokenSecret *corev1.Secret
+
 	for _, v := range saTokenList.Items {
 		v := v
-		switch v.Type {
-		case corev1.SecretTypeServiceAccountToken:
+		if v.Type == corev1.SecretTypeServiceAccountToken {
 			if v.Namespace == saNamespace && v.Annotations[corev1.ServiceAccountNameKey] == saName {
 				return &v, nil
 			}
 		}
 	}
+
 	if tokenSecret == nil {
 		return nil, ErrServiceAccountTokenNotFound
 	}

--- a/pkg/indexer/indexer.go
+++ b/pkg/indexer/indexer.go
@@ -1,3 +1,6 @@
+// Copyright 2020-2024 Project Capsule Authors.
+// SPDX-License-Identifier: Apache-2.0
+
 package indexer
 
 import (


### PR DESCRIPTION
This PR introduces linting of the code, and:
- Set allowed modules explicitely with depguard
- Add missing license header.
- Fix GCI referenced project go module name.
