### PR TITLE
chore(charts): bump app version to 0.2.0

### DIFF
--- a/charts/capsule-addon-fluxcd/Chart.yaml
+++ b/charts/capsule-addon-fluxcd/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.0
+appVersion: 0.2.0

--- a/charts/capsule-addon-fluxcd/README.md
+++ b/charts/capsule-addon-fluxcd/README.md
@@ -1,6 +1,6 @@
 # capsule-addon-fluxcd
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
This PR bumps the app version of the Helm chart.