### PR TITLE
chore(charts): bump chart versin to 0.1.2

### DIFF
--- a/charts/capsule-addon-fluxcd/Chart.yaml
+++ b/charts/capsule-addon-fluxcd/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/capsule-addon-fluxcd/README.md
+++ b/charts/capsule-addon-fluxcd/README.md
@@ -1,6 +1,6 @@
 # capsule-addon-fluxcd
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/e2e/charts/serviceaccount_test.go
+++ b/e2e/charts/serviceaccount_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Creating a new ServiceAccount", func() {
 		})
 
 		Context("set as owner of the Tenant", func() {
-			BeforeEach(func() {
+			BeforeAll(func() {
 				Expect(adminClient.Create(context.TODO(), &capsulev1beta2.Tenant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: TenantName,
@@ -66,7 +66,7 @@ var _ = Describe("Creating a new ServiceAccount", func() {
 					},
 				})).Should(Succeed())
 			})
-			AfterEach(func() {
+			AfterAll(func() {
 				Expect(adminClient.Delete(context.TODO(), &capsulev1beta2.Tenant{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: TenantName,


### PR DESCRIPTION
This PR bumps the Helm chart version to 0.1.2.

Furthermore, it introduces a fix for the e2e test for the Helm chart.