### PR TITLE
chore(.github): bump commitlint and add config

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@0d749a1a91d4770e983a7b8f83d4a3f0e7e0874e #v5.4.4
+      - uses: wagoid/commitlint-github-action@0184f5a228ee06430bb9e67d65f73a1a6767496a # v6.2.0
         with:
           firstParent: true

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,20 @@
+const Configuration = {
+    extends: ['@commitlint/config-conventional'],
+    plugins: ['commitlint-plugin-function-rules'],
+    rules: {
+      'type-enum': [2, 'always', ['chore', 'ci', 'docs', 'feat', 'test', 'fix', 'sec']],
+      'body-max-line-length': [1, 'always', 500],
+      'subject-case': [2, 'always', ['lower-case', 'sentence-case', 'upper-case']],
+    },
+    /*
+     * Whether commitlint uses the default ignore rules, see the description above.
+     */
+    defaultIgnores: true,
+    /*
+     * Custom URL to show upon failure
+     */
+    helpUrl:
+      'https://github.com/projectcapsule/capsule-addon-fluxcd?tab=readme-ov-file#development',
+  };
+  
+  module.exports = Configuration;


### PR DESCRIPTION
This PR bumps commit-lint GH action to 6.2.0 and adds a custom configuration.
The config resembles the ones we have across the Capsule organization.
In particular we needed to increase the maximum length of the commit body to allow more information especially for dependencies bumpings.