### PR TITLE
chore(charts): add support for proxy url

### DIFF
--- a/charts/capsule-addon-fluxcd/Chart.yaml
+++ b/charts/capsule-addon-fluxcd/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.0
+appVersion: 0.2.2

--- a/charts/capsule-addon-fluxcd/README.md
+++ b/charts/capsule-addon-fluxcd/README.md
@@ -1,6 +1,6 @@
 # capsule-addon-fluxcd
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -20,9 +20,10 @@ A Helm chart for Kubernetes
 | options.logLevel | string | `"4"` | Set the log verbosity of the capsule with a value from 1 to 10 |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
-| proxy | object | `{"tls":{"secretKey":"ca","secretName":"capsule-proxy"}}` | - Configure deployments settings related to the Capsule proxy |
+| proxy | object | `{"tls":{"secretKey":"ca","secretName":"capsule-proxy"},"url":"https://capsule-proxy.capsule-system.svc:9001"}` | - Configure deployments settings related to the Capsule proxy |
 | proxy.tls.secretKey | string | `"ca"` | - Set the Secret key that contains the CA certificate of the proxy |
 | proxy.tls.secretName | string | `"capsule-proxy"` | - Set the Secret name that contains the CA certificate of the proxy |
+| proxy.url | string | `"https://capsule-proxy.capsule-system.svc:9001"` | - Set the Capsule proxy Service URL |
 | rbac.annotations | object | `{}` |  |
 | rbac.create | bool | `true` |  |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":10080}}` | Configure the readiness probe using Deployment probe spec |

--- a/charts/capsule-addon-fluxcd/templates/deployment.yaml
+++ b/charts/capsule-addon-fluxcd/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
           args:
           - manager
           - --proxy-ca-path=/tmp/proxy-tls/{{ .Values.proxy.tls.secretKey }}
+          - --proxy-url={{ .Values.proxy.url }}
           - --zap-log-level={{ default 4 .Values.options.logLevel }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/capsule-addon-fluxcd/values.yaml
+++ b/charts/capsule-addon-fluxcd/values.yaml
@@ -21,6 +21,8 @@ proxy:
     secretName: "capsule-proxy"
     # --- Set the Secret key that contains the CA certificate of the proxy
     secretKey: "ca"
+  # --- Set the Capsule proxy Service URL
+  url: https://capsule-proxy.capsule-system.svc:9001
 
 # -- Configure the liveness probe using Deployment probe spec
 livenessProbe:


### PR DESCRIPTION
This PR introduces support in the Helm chart for specifying a custom URL of the Capsule Proxy.
This URL will be the one being set in the kubeconfig generated by the addon as `server`.

Furthermore, the addon image is bumped to 0.2.2.