### PR TITLE
ci: update goreleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,7 +49,8 @@ signs:
 # https://goreleaser.com/customization/ko/?h=kos
 kos:
   - base_image: cgr.dev/chainguard/static
-    repository: ghcr.io/projectcapsule/capsule-addon-fluxcd
+    repositories:
+      - ghcr.io/projectcapsule/capsule-addon-fluxcd
     bare: true
     tags:
       - '{{ .Version }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,7 @@ signs:
     certificate: '${artifact}.pem'
     args:
       - sign-blob
+      - '--bundle=${artifact}.sigstore'
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'


### PR DESCRIPTION
Update goreleaser configuration:
- ko build deprecated `repository` to `repositories` field
- cosign v3 new `--bundle` required output path argument  